### PR TITLE
Use explicit exception

### DIFF
--- a/boundaryservice/management/commands/loadshapefiles.py
+++ b/boundaryservice/management/commands/loadshapefiles.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
             try:
                 set = BoundarySet.objects.get(name=kind)
                 log.info("Using existing BoundarySet [%s]" % set.slug)
-            except:
+            except BoundarySet.DoesNotExist:
                 set = BoundarySet.objects.create(
                     name=kind,
                     singular=config['singular'],


### PR DESCRIPTION
Not having an explicit exception here hid the fact that I hadn't run `python manage.py syncdb`.
