### PR TITLE
An array of fixes aimed at getting boundaryservice to work with Django 1.5 and the latest version of tastypie

### DIFF
--- a/boundaryservice/admin.py
+++ b/boundaryservice/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
+from tastypie.models import ApiAccess
 from django.contrib.gis.admin import OSMGeoAdmin
 from boundaryservice.models import BoundarySet, Boundary
+
+
+class ApiAccessAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(ApiAccess, ApiAccessAdmin)
 
 
 class BoundarySetAdmin(admin.ModelAdmin):

--- a/boundaryservice/admin.py
+++ b/boundaryservice/admin.py
@@ -1,23 +1,13 @@
 from django.contrib import admin
 from django.contrib.gis.admin import OSMGeoAdmin
-from tastypie.models import ApiAccess, ApiKey
-
 from boundaryservice.models import BoundarySet, Boundary
 
-class ApiAccessAdmin(admin.ModelAdmin):
-    pass
-
-admin.site.register(ApiAccess, ApiAccessAdmin)
-
-class ApiKeyAdmin(admin.ModelAdmin):
-    pass
-
-admin.site.register(ApiKey, ApiKeyAdmin)
 
 class BoundarySetAdmin(admin.ModelAdmin):
     list_filter = ('authority', 'domain')
 
 admin.site.register(BoundarySet, BoundarySetAdmin)
+
 
 class BoundaryAdmin(OSMGeoAdmin):
     list_display = ('kind', 'name', 'external_id')

--- a/boundaryservice/models.py
+++ b/boundaryservice/models.py
@@ -116,6 +116,7 @@ class Boundary(SluggedModel):
 
     class Meta:
         ordering = ('kind', 'display_name')
+        verbose_name_plural = 'boundaries'
 
     def __unicode__(self):
         """

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -86,6 +86,8 @@ class SluggedResource(ModelResource):
         
         if isinstance(bundle_or_obj, Bundle):
             kwargs['slug'] = bundle_or_obj.obj.slug
+        elif bundle_or_obj is None:
+            kwargs['slug'] = None
         else:
             kwargs['slug'] = bundle_or_obj.slug
         

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
         'boundaryservice.management.commands'
     ],
     install_requires = [
-        'django-tastypie==0.9.9'
+        'django-tastypie==0.9.12'
     ]
 )


### PR DESCRIPTION
- Upgrade tastypie requirement
- Fix redundant admin declaration
- Hack one of the tastyhacks to keep it working
- Fix plural name on Boundary model class
