### PR TITLE
Fixed plural name for the Boundary model

### DIFF
--- a/boundaryservice/models.py
+++ b/boundaryservice/models.py
@@ -116,6 +116,7 @@ class Boundary(SluggedModel):
 
     class Meta:
         ordering = ('kind', 'display_name')
+        verbose_name_plural = 'boundaries'
 
     def __unicode__(self):
         """


### PR DESCRIPTION
Just one small change to the `Meta` declaration.
