### PR TITLE
Upgrade to work with Django 1.5 and tastypie 0.9.12

### DIFF
--- a/boundaryservice/admin.py
+++ b/boundaryservice/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
+from tastypie.models import ApiAccess
 from django.contrib.gis.admin import OSMGeoAdmin
 from boundaryservice.models import BoundarySet, Boundary
+
+
+class ApiAccessAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(ApiAccess, ApiAccessAdmin)
 
 
 class BoundarySetAdmin(admin.ModelAdmin):

--- a/boundaryservice/admin.py
+++ b/boundaryservice/admin.py
@@ -1,23 +1,13 @@
 from django.contrib import admin
 from django.contrib.gis.admin import OSMGeoAdmin
-from tastypie.models import ApiAccess, ApiKey
-
 from boundaryservice.models import BoundarySet, Boundary
 
-class ApiAccessAdmin(admin.ModelAdmin):
-    pass
-
-admin.site.register(ApiAccess, ApiAccessAdmin)
-
-class ApiKeyAdmin(admin.ModelAdmin):
-    pass
-
-admin.site.register(ApiKey, ApiKeyAdmin)
 
 class BoundarySetAdmin(admin.ModelAdmin):
     list_filter = ('authority', 'domain')
 
 admin.site.register(BoundarySet, BoundarySetAdmin)
+
 
 class BoundaryAdmin(OSMGeoAdmin):
     list_display = ('kind', 'name', 'external_id')

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -80,14 +80,18 @@ class SluggedResource(ModelResource):
         """
         Override URI generation to use slugs.
         """
+        # If there's no bundle_or_obj, something newer
+        # versions of tastypie will try, just go with
+        # the default method.
+        if not bundle_or_obj:
+            return super(ModelResource, self).get_resource_uri(bundle_or_obj)
+        
         kwargs = {
             'resource_name': self._meta.resource_name,
         }
         
         if isinstance(bundle_or_obj, Bundle):
             kwargs['slug'] = bundle_or_obj.obj.slug
-        elif bundle_or_obj is None:
-            kwargs['slug'] = None
         else:
             kwargs['slug'] = bundle_or_obj.slug
         

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -86,6 +86,8 @@ class SluggedResource(ModelResource):
         
         if isinstance(bundle_or_obj, Bundle):
             kwargs['slug'] = bundle_or_obj.obj.slug
+        elif bundle_or_obj is None:
+            kwargs['slug'] = None
         else:
             kwargs['slug'] = bundle_or_obj.slug
         

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -76,7 +76,7 @@ class SluggedResource(ModelResource):
             url(r"^(?P<resource_name>%s)/(?P<slug>[\w\d_.-]+)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
             ]
 
-    def get_resource_uri(self, bundle_or_obj):
+    def get_resource_uri(self, bundle_or_obj=None):
         """
         Override URI generation to use slugs.
         """

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
         'boundaryservice.management.commands'
     ],
     install_requires = [
-        'django-tastypie==0.9.9'
+        'django-tastypie==0.9.12'
     ]
 )


### PR DESCRIPTION
This requires
- Upgraded setup.py to pull the latest tastypie
- Removing an boundaryservice admin.py registration of tastypie model that tastypie now registers on its own
- A further hack of tastyhacks.py's `get_resource_uri` method
