### PR TITLE
loadshapefiles refactor for speed

### DIFF
--- a/boundaryservice/admin.py
+++ b/boundaryservice/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
+from tastypie.models import ApiAccess
 from django.contrib.gis.admin import OSMGeoAdmin
 from boundaryservice.models import BoundarySet, Boundary
+
+
+class ApiAccessAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(ApiAccess, ApiAccessAdmin)
 
 
 class BoundarySetAdmin(admin.ModelAdmin):

--- a/boundaryservice/admin.py
+++ b/boundaryservice/admin.py
@@ -1,23 +1,13 @@
 from django.contrib import admin
 from django.contrib.gis.admin import OSMGeoAdmin
-from tastypie.models import ApiAccess, ApiKey
-
 from boundaryservice.models import BoundarySet, Boundary
 
-class ApiAccessAdmin(admin.ModelAdmin):
-    pass
-
-admin.site.register(ApiAccess, ApiAccessAdmin)
-
-class ApiKeyAdmin(admin.ModelAdmin):
-    pass
-
-admin.site.register(ApiKey, ApiKeyAdmin)
 
 class BoundarySetAdmin(admin.ModelAdmin):
     list_filter = ('authority', 'domain')
 
 admin.site.register(BoundarySet, BoundarySetAdmin)
+
 
 class BoundaryAdmin(OSMGeoAdmin):
     list_display = ('kind', 'name', 'external_id')

--- a/boundaryservice/models.py
+++ b/boundaryservice/models.py
@@ -116,6 +116,7 @@ class Boundary(SluggedModel):
 
     class Meta:
         ordering = ('kind', 'display_name')
+        verbose_name_plural = 'boundaries'
 
     def __unicode__(self):
         """

--- a/boundaryservice/models.py
+++ b/boundaryservice/models.py
@@ -1,9 +1,8 @@
 import re
-
 from django.contrib.gis.db import models
-
 from boundaryservice.fields import ListField, JSONField
 from boundaryservice.utils import get_site_url_root
+
 
 class SluggedModel(models.Model):
     """
@@ -36,23 +35,25 @@ class SluggedModel(models.Model):
                 slug_txt = str(self)
             else:
                 return
-            slug = slugify(slug_txt)
-
-            itemModel = self.__class__
-            # the following gets all existing slug values
-            allSlugs = set(sl.values()[0] for sl in itemModel.objects.values("slug"))
-            if slug in allSlugs:
-                counterFinder = re.compile(r'-\d+$')
-                counter = 2
-                slug = "%s-%i" % (slug, counter)
-                while slug in allSlugs:
-                    slug = re.sub(counterFinder,"-%i" % counter, slug)
-                    counter += 1
-
-            setattr(self,"slug",slug)
-
-    def fully_qualified_url(self):        
+            original_slug = slugify(slug_txt)
+            queryset = self.__class__._default_manager.all()
+            if not queryset.filter(slug=original_slug).count():
+                setattr(self, "slug", original_slug)
+            else:
+                slug = ''
+                next = 2
+                while not slug or queryset.filter(slug=slug).count():
+                    slug = original_slug
+                    end = '-%s' % next
+                    if len(slug) + len(end) > 256:
+                        slug = slug[:200-len(end)]
+                    slug = '%s%s' % (slug, end)
+                    next += 1
+                setattr(self, "slug", slug)
+    
+    def fully_qualified_url(self):
         return get_site_url_root() + self.get_absolute_url()
+
 
 class BoundarySet(SluggedModel):
     """
@@ -87,6 +88,7 @@ class BoundarySet(SluggedModel):
         Print plural names.
         """
         return unicode(self.name)
+
 
 class Boundary(SluggedModel):
     """

--- a/boundaryservice/resources.py
+++ b/boundaryservice/resources.py
@@ -3,31 +3,34 @@ import re
 from django.contrib.gis.measure import D
 from tastypie import fields
 from tastypie.serializers import Serializer
-from boundaryservice.serializers import GeoSerializer
+from boundaryservice.serializers import BoundaryGeoSerializer
+from boundaryservice.serializers import BoundarySetGeoSerializer
 
 from boundaryservice.authentication import NoOpApiKeyAuthentication
 from boundaryservice.models import BoundarySet, Boundary
 from boundaryservice.tastyhacks import SluggedResource
 from boundaryservice.throttle import AnonymousThrottle
 
+
 class BoundarySetResource(SluggedResource):
     boundaries = fields.ToManyField('boundaryservice.resources.BoundaryResource', 'boundaries')
 
     class Meta:
         queryset = BoundarySet.objects.all()
-        serializer = Serializer(formats=['json', 'jsonp'], content_types = {'json': 'application/json', 'jsonp': 'text/javascript'})
+        serializer = BoundarySetGeoSerializer()
         resource_name = 'boundary-set'
         excludes = ['id', 'singular', 'kind_first']
         allowed_methods = ['get']
         authentication = NoOpApiKeyAuthentication()
         #throttle = AnonymousThrottle(throttle_at=100) 
 
+
 class BoundaryResource(SluggedResource):
     set = fields.ForeignKey(BoundarySetResource, 'set')
 
     class Meta:
         queryset = Boundary.objects.all()
-        serializer = GeoSerializer()
+        serializer = BoundaryGeoSerializer()
         resource_name = 'boundary'
         excludes = ['id', 'display_name']
         allowed_methods = ['get']

--- a/boundaryservice/resources.py
+++ b/boundaryservice/resources.py
@@ -3,6 +3,7 @@ import re
 from django.contrib.gis.measure import D
 from tastypie import fields
 from tastypie.serializers import Serializer
+from boundaryservice.serializers import GeoSerializer
 
 from boundaryservice.authentication import NoOpApiKeyAuthentication
 from boundaryservice.models import BoundarySet, Boundary
@@ -26,7 +27,7 @@ class BoundaryResource(SluggedResource):
 
     class Meta:
         queryset = Boundary.objects.all()
-        serializer = Serializer(formats=['json', 'jsonp'], content_types = {'json': 'application/json', 'jsonp': 'text/javascript'})
+        serializer = GeoSerializer()
         resource_name = 'boundary'
         excludes = ['id', 'display_name']
         allowed_methods = ['get']

--- a/boundaryservice/serializers.py
+++ b/boundaryservice/serializers.py
@@ -1,0 +1,76 @@
+import json
+from tastypie.serializers import Serializer
+from django.template.loader import render_to_string
+from django.core.serializers.json import DjangoJSONEncoder
+
+
+class GeoSerializer(Serializer):
+    """
+    Adds some common geospatial outputs to the standard serializer.
+    
+    Supported formats:
+        
+        * JSON (Standard issue)
+        * JSONP (Standard issue)
+        * KML
+        * GeoJSON
+    
+    """
+    formats = [
+        'json',
+        'jsonp',
+        'kml',
+        'geojson',
+    ]
+    content_types = {
+        'json': 'application/json',
+        'jsonp': 'text/javascript',
+        'kml': 'application/vnd.google-earth.kml+xml',
+        'geojson': 'application/geo+json',
+    }
+    
+    def sniff_shape_attr(self, data):
+        """
+        Inspect the request and figure out which shape type
+        the user would like us to return.
+        """
+        if data.request.GET.get('shape_type', '') == 'full':
+            return 'shape'
+        else:
+            return 'simple_shape'
+    
+    def to_geojson(self, data, options=None):
+        """
+        Converts the bundle to a GeoJSON seralization.
+        """
+        # Hook the GeoJSON output to the object
+        simple_obj = self.to_simple(data, options)
+        shape_attr = self.sniff_shape_attr(data)
+        simple_obj['geojson'] = getattr(data.obj, shape_attr).geojson
+        # Get the properties serialized in GeoJSON style
+        properties = dict(
+            (k, v) for k, v in simple_obj.items()
+                if k not in ['shape', 'simple_shape', 'geojson']
+        )
+        simple_obj['properties_json'] = json.dumps(
+            properties,
+            cls=DjangoJSONEncoder,
+            sort_keys=True
+        )
+        # Render the result using a template and pass it out
+        return render_to_string('object_detail.geojson', {
+            'obj': simple_obj,
+        })
+    
+    def to_kml(self, data, options=None):
+        """
+        Converts the bundle to a KML serialization.
+        """
+        # Hook the KML output to the object
+        simple_obj = self.to_simple(data, options)
+        shape_attr = self.sniff_shape_attr(data)
+        simple_obj['kml'] = getattr(data.obj, shape_attr).kml
+        # Render the result using a template and pass it out
+        return render_to_string('object_detail.kml', {
+            'obj': simple_obj,
+        })

--- a/boundaryservice/shp.py
+++ b/boundaryservice/shp.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+import os
+import zipfile
+import tempfile
+import datetime
+from osgeo import ogr, osr
+from django.http import HttpResponse
+from django.utils.encoding import smart_str
+from django.contrib.gis.db.models.fields import GeometryField
+from django.contrib.gis.gdal import check_err, OGRGeomType
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+
+class ShpSerializer(object):
+    """
+    Mashes a queryset into a zip response.
+    
+    Modified from the ShpResponer in Dane Springmeyer's django-shapes.
+    """
+    def __init__(self, queryset, readme=None, geo_field=None, file_name='boundary-set',
+        excludes=[]):
+        self.queryset = queryset
+        self.readme = readme
+        self.geo_field = geo_field
+        self.file_name = file_name
+        self.excludes = excludes
+    
+    def __call__(self, *args, **kwargs):
+        tmp = self.write_shapefile_to_tmp_file(self.queryset)
+        return self.zip_response(tmp,self.file_name,self.readme)
+    
+    def get_metadata_attr(self):
+        fields = []
+        for obj in self.queryset:
+            cand_list = [
+                f for f in obj.metadata.keys()
+            ]
+            for cand in cand_list:
+                if cand not in fields:
+                    fields.append(cand)
+        return fields
+    
+    def get_attributes(self):
+        fields = self.queryset[0].__class__._meta.fields
+        attr = [f for f in fields if not isinstance(f, GeometryField)
+            and f.name not in self.excludes]
+        return attr
+    
+    def get_geo_field(self):
+        geo_field_by_name = [fld for fld 
+            in self.queryset[0].__class__._meta.fields 
+            if fld.name == self.geo_field
+        ]
+        if not geo_field_by_name:
+            raise ValueError("Geodjango geometry field not found with the name '%s'" % (self.geo_field))
+        else:
+            geo_field = geo_field_by_name[0]
+        return geo_field
+    
+    def write_shapefile_to_tmp_file(self,queryset):
+        tmp = tempfile.NamedTemporaryFile(suffix='.shp', mode = 'w+b')
+        # we must close the file for GDAL to be able to open and write to it
+        tmp.close()
+        args = tmp.name, queryset, self.get_geo_field()
+        self.write_with_native_bindings(*args)
+        return tmp.name
+    
+    def zip_response(self,shapefile_path,file_name,readme=None):
+        buffer = StringIO()
+        zip = zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED)
+        files = ['shp','shx','prj','dbf']
+        for item in files:
+            filename = '%s.%s' % (shapefile_path.replace('.shp',''), item)
+            zip.write(filename, arcname='%s.%s' % (file_name.replace('.shp',''), item))
+        if readme:
+            zip.writestr('README.txt',readme)
+        zip.close()
+        buffer.flush()
+        zip_stream = buffer.getvalue()
+        buffer.close()
+        return zip_stream
+    
+    def create_field(self, layer, name):
+        field_defn = ogr.FieldDefn(str(name)[:10], ogr.OFTString)
+        field_defn.SetWidth(255)
+        if layer.CreateField(field_defn) != 0:
+            raise Exception('Faild to create field')
+    
+    def set_field(self, feat, name, value):
+        try:
+            string_value = str(value)
+        except UnicodeEncodeError, E:
+            string_value = ''
+        feat.SetField(str(name)[:10], string_value)
+    
+    def write_with_native_bindings(self,tmp_name,queryset,geo_field):
+        """ Write a shapefile out to a file from a geoqueryset.
+        
+        Written by Jared Kibele and Dane Springmeyer.
+        
+        In this case we use the python bindings available with a build
+        of gdal when compiled with --with-python, instead of the ctypes-based 
+        bindings that GeoDjango provides.
+        
+        """
+        dr = ogr.GetDriverByName('ESRI Shapefile')
+        ds = dr.CreateDataSource(tmp_name)
+        if ds is None:
+            raise Exception('Could not create file!')
+        
+        if hasattr(geo_field,'geom_type'):
+            ogr_type = OGRGeomType(geo_field.geom_type).num
+        else:
+            ogr_type = OGRGeomType(geo_field._geom).num
+        
+        native_srs = osr.SpatialReference()
+        if hasattr(geo_field,'srid'):
+            native_srs.ImportFromEPSG(geo_field.srid)
+        else:
+            native_srs.ImportFromEPSG(geo_field._srid)
+        
+        layer = ds.CreateLayer('lyr', srs=native_srs, geom_type=ogr_type)
+        
+        # Get the standard shape attributes
+        attributes = self.get_attributes()
+        
+        # Create columns for the standard shape attributes
+        [self.create_field(layer, field.name) for field in attributes]
+        
+        # Create columnes for all the possible metadata attributes
+        [self.create_field(layer, key) for key in self.get_metadata_attr()]
+        
+        feature_def = layer.GetLayerDefn()
+        
+        for item in queryset:
+            feat = ogr.Feature( feature_def )
+            
+            for field in attributes:
+                value = getattr(item, field.name)
+                self.set_field(feat, field.name, value)
+            
+            for key, value in item.metadata.items():
+                self.set_field(feat, key, value)
+            
+            geom = getattr(item, geo_field.name)
+            if geom:
+                ogr_geom = ogr.CreateGeometryFromWkt(geom.wkt)
+                check_err(feat.SetGeometry(ogr_geom))
+            else:
+                pass
+            
+            check_err(layer.CreateFeature(feat))
+        
+        ds.Destroy()

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -80,14 +80,18 @@ class SluggedResource(ModelResource):
         """
         Override URI generation to use slugs.
         """
+        # If there's no bundle_or_obj, something newer
+        # versions of tastypie will try, just go with
+        # the default method.
+        if not bundle_or_obj:
+            return super(ModelResource, self).get_resource_uri(bundle_or_obj)
+        
         kwargs = {
             'resource_name': self._meta.resource_name,
         }
         
         if isinstance(bundle_or_obj, Bundle):
             kwargs['slug'] = bundle_or_obj.obj.slug
-        elif bundle_or_obj is None:
-            kwargs['slug'] = None
         else:
             kwargs['slug'] = bundle_or_obj.slug
         

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -86,6 +86,8 @@ class SluggedResource(ModelResource):
         
         if isinstance(bundle_or_obj, Bundle):
             kwargs['slug'] = bundle_or_obj.obj.slug
+        elif bundle_or_obj is None:
+            kwargs['slug'] = None
         else:
             kwargs['slug'] = bundle_or_obj.slug
         

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -76,7 +76,7 @@ class SluggedResource(ModelResource):
             url(r"^(?P<resource_name>%s)/(?P<slug>[\w\d_.-]+)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
             ]
 
-    def get_resource_uri(self, bundle_or_obj):
+    def get_resource_uri(self, bundle_or_obj=None):
         """
         Override URI generation to use slugs.
         """

--- a/boundaryservice/templates/object_detail.geojson
+++ b/boundaryservice/templates/object_detail.geojson
@@ -1,7 +1,14 @@
-{
+{{% load boundaryservice_tags %}
     "type": "Feature",
-    "id": "{{ obj.external_id }}",
-    "properties": {{ obj.properties_json|safe }},
+    "properties": {
+        "kind": "{{ obj.kind }}",
+        "external_id": "{{ obj.external_id }}",
+        "name": "{{ obj.name }}",
+        "slug": "{{ obj.slug }}",
+        "set": "{{ obj.set_uri }}",
+        "metadata": {{ obj.metadata|jsonify|safe }},
+        "resource_uri": "{{ obj.resource_uri }}"
+    },
     "geometry": {{ obj.geojson|safe }}
 }
 

--- a/boundaryservice/templates/object_detail.geojson
+++ b/boundaryservice/templates/object_detail.geojson
@@ -1,0 +1,7 @@
+{
+    "type": "Feature",
+    "id": "{{ obj.external_id }}",
+    "properties": {{ obj.properties_json|safe }},
+    "geometry": {{ obj.geojson|safe }}
+}
+

--- a/boundaryservice/templates/object_detail.kml
+++ b/boundaryservice/templates/object_detail.kml
@@ -2,8 +2,28 @@
 <kml xmlns="http://earth.google.com/kml/2.2">
 <Document>
 <Placemark>
-  <name>{{ obj.name }}</name>
-  {{ obj.kml|safe }}
+    <name>{{ obj.name }}</name>
+    <ExtendedData>
+      <Data name="kind">
+        <value>{{ obj.kind }}</value>
+      </Data>
+      <Data name="external_id">
+        <value>{{ obj.external_id }}</value>
+      </Data>
+      <Data name="slug">
+        <value>{{ obj.slug }}</value>
+      </Data>
+      <Data name="set">
+        <value>{{ obj.set_uri }}</value>
+      </Data>
+      <Data name="resource_uri">
+        <value>{{ obj.resource_uri }}</value>
+      </Data>{% for key, value in obj.metadata.items %}
+      <Data name="{{ key }}">
+         <value>{{ value }}</value>
+      </Data>{% endfor %}
+    </ExtendedData>
+    {{ obj.kml|safe }}
 </Placemark>
 </Document>
 </kml>

--- a/boundaryservice/templates/object_detail.kml
+++ b/boundaryservice/templates/object_detail.kml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://earth.google.com/kml/2.2">
+<Document>
+<Placemark>
+  <name>{{ obj.name }}</name>
+  {{ obj.kml|safe }}
+</Placemark>
+</Document>
+</kml>

--- a/boundaryservice/templates/object_list.geojson
+++ b/boundaryservice/templates/object_list.geojson
@@ -1,0 +1,19 @@
+{{% load boundaryservice_tags %}
+    "type": "FeatureCollection",
+    "features": [{% for obj in boundary_list %}
+        {
+            "type": "Feature",
+            "properties": {
+                "kind": "{{ obj.kind }}",
+                "external_id": "{{ obj.external_id }}",
+                "name": "{{ obj.name }}",
+                "slug": "{{ obj.slug }}",
+                "set": "/1.0/boundary-set/{{ boundary_set.slug }}/",
+                "centroid": {{ obj.centroid.geojson|safe }},
+                "metadata": {{ obj.metadata|jsonify|safe }},
+                "resource_uri": "/1.0/boundary/{{ obj.slug }}/"
+            },
+            "geometry": {{ obj.geojson|safe }}
+        }{% if not forloop.last %},{% endif %}
+    {% endfor %}]
+}

--- a/boundaryservice/templates/object_list.geojson
+++ b/boundaryservice/templates/object_list.geojson
@@ -8,10 +8,9 @@
                 "external_id": "{{ obj.external_id }}",
                 "name": "{{ obj.name }}",
                 "slug": "{{ obj.slug }}",
-                "set": "/1.0/boundary-set/{{ boundary_set.slug }}/",
-                "centroid": {{ obj.centroid.geojson|safe }},
+                "set": "{{ obj.set_uri }}",
                 "metadata": {{ obj.metadata|jsonify|safe }},
-                "resource_uri": "/1.0/boundary/{{ obj.slug }}/"
+                "resource_uri": "{{ obj.resource_uri }}"
             },
             "geometry": {{ obj.geojson|safe }}
         }{% if not forloop.last %},{% endif %}

--- a/boundaryservice/templates/object_list.kml
+++ b/boundaryservice/templates/object_list.kml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://earth.google.com/kml/2.2">
+<Document>
+{% for obj in boundary_list %}
+<Placemark>
+  <name>{{ obj.name }}</name>
+  {{ obj.kml|safe }}
+</Placemark>
+{% endfor %}
+</Document>
+</kml>

--- a/boundaryservice/templates/object_list.kml
+++ b/boundaryservice/templates/object_list.kml
@@ -3,8 +3,28 @@
 <Document>
 {% for obj in boundary_list %}
 <Placemark>
-  <name>{{ obj.name }}</name>
-  {{ obj.kml|safe }}
+    <name>{{ obj.name }}</name>
+    <ExtendedData>
+      <Data name="kind">
+        <value>{{ obj.kind }}</value>
+      </Data>
+      <Data name="external_id">
+        <value>{{ obj.external_id }}</value>
+      </Data>
+      <Data name="slug">
+        <value>{{ obj.slug }}</value>
+      </Data>
+      <Data name="set">
+        <value>{{ obj.set_uri }}</value>
+      </Data>
+      <Data name="resource_uri">
+        <value>{{ obj.resource_uri }}</value>
+      </Data>{% for key, value in obj.metadata.items %}
+      <Data name="{{ key }}">
+         <value>{{ value }}</value>
+      </Data>{% endfor %}
+    </ExtendedData>
+    {{ obj.kml|safe }}
 </Placemark>
 {% endfor %}
 </Document>

--- a/boundaryservice/templatetags/boundaryservice_tags.py
+++ b/boundaryservice/templatetags/boundaryservice_tags.py
@@ -1,0 +1,15 @@
+import json
+from django.template import Library
+from django.db.models.query import QuerySet
+from django.utils.safestring import mark_safe
+from django.core.serializers import serialize
+from django.core.serializers.json import DjangoJSONEncoder
+
+register = Library()
+
+@register.filter
+def jsonify(obj):
+    if isinstance(obj, QuerySet):
+        return mark_safe(serialize('json', obj))
+    return mark_safe(json.dumps(obj, cls=DjangoJSONEncoder))
+

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
         'boundaryservice.management.commands'
     ],
     install_requires = [
-        'django-tastypie==0.9.9'
+        'django-tastypie==0.9.12'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'boundaryservice.management.commands'
     ],
     install_requires = [
-        'django-tastypie==0.9.12'
+        'django-tastypie==0.9.12',
+        'GDAL==1.9.1'
     ]
 )


### PR DESCRIPTION
I was able to drastically increase the speed of the loadshapefile management comment by changing a few small things. 
1. The `len(layer)` to set the `count` attribute of new `BoundarySet` objects takes a really long time, to my surprise. Just initializing the set with zero in that field, and then letting the count be calculated via SQL after everything's in the database is way faster. And since the app was doing that recalculation anyway, you don't have to add any code.
2. A modification of the process that guarantees a unique slug that doesn't require pulling every single slug out of the database and into memory with every save call. I replaced that with some SQL count queries that I suspect are faster.

The result is that time it took my laptop to load a SHP file with ~3000 features dropped from more than 8 hours to less than 3 minutes.
