### PR TITLE
Added a new custom 'bbox' filter to the BoundaryResource

### DIFF
--- a/boundaryservice/resources.py
+++ b/boundaryservice/resources.py
@@ -3,6 +3,7 @@ import re
 from django.contrib.gis.measure import D
 from tastypie import fields
 from tastypie.serializers import Serializer
+from django.contrib.gis.geos import Polygon
 
 from boundaryservice.authentication import NoOpApiKeyAuthentication
 from boundaryservice.models import BoundarySet, Boundary
@@ -96,6 +97,13 @@ class BoundaryResource(SluggedResource):
             slug = filters['intersects']
             bounds = Boundary.objects.get(slug=slug)
 
-            orm_filters.update({'shape__intersects': bounds.shape})            
+            orm_filters.update({'shape__intersects': bounds.shape})
+
+        if 'bbox' in filters:
+            xmin, ymin, xmax, ymax = filters['bbox'].split(",")
+            bbox = (xmin, ymin, xmax, ymax)
+            bbox = Polygon.from_bbox(bbox)
+
+            orm_filters.update({'shape__intersects': bbox})
 
         return orm_filters


### PR DESCRIPTION
Allows you filter using a bounding box. I find this useful when I only want to retrieve the boundaries that fall within the current map view.
