### PR TITLE
Allowing for slug filtering to be in boundaries.

### DIFF
--- a/boundaryservice/fields.py
+++ b/boundaryservice/fields.py
@@ -1,9 +1,10 @@
 """
 Custom model fields.
 """
+import json
+
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.utils import simplejson as json
 
 class ListField(models.TextField):
     """

--- a/boundaryservice/resources.py
+++ b/boundaryservice/resources.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.gis.measure import D
 from tastypie import fields
 from tastypie.serializers import Serializer
+from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from django.contrib.gis.geos import Polygon
 
 from boundaryservice.authentication import NoOpApiKeyAuthentication
@@ -50,6 +51,9 @@ class BoundaryResource(SluggedResource):
         allowed_methods = ['get']
         authentication = NoOpApiKeyAuthentication()
         throttle = throttle_cls
+        filtering = {
+            "slug": ALL
+        }
 
     def alter_list_data_to_serialize(self, request, data):
         """

--- a/boundaryservice/tastyhacks.py
+++ b/boundaryservice/tastyhacks.py
@@ -1,6 +1,7 @@
+import json
+
 from django.conf.urls.defaults import url
 from django.contrib.gis.db.models import GeometryField
-from django.utils import simplejson
 
 from tastypie.bundle import Bundle
 from tastypie.fields import ApiField, CharField
@@ -60,7 +61,7 @@ class GeometryApiField(ApiField):
 
         # Get ready-made geojson serialization and then convert it _back_ to a Python object
         # so that Tastypie can serialize it as part of the bundle
-        return simplejson.loads(value.geojson)
+        return json.loads(value.geojson)
 
 
 class SluggedResource(ModelResource):


### PR DESCRIPTION
This fixes #42 and allows for any filtering on slugs, so I can do something like:

http://localhost:8000/1.0/boundary/?slug__in=2715101864-minor-civil-division-2010,2713702890-minor-civil-division-2010

I am not sure if this should really go upstream, but I don't have the knowledge to override this sort of thing for our instance only.
